### PR TITLE
Fix duplicate isGenerating declaration

### DIFF
--- a/client/src/components/character/CharacterTemplates.tsx
+++ b/client/src/components/character/CharacterTemplates.tsx
@@ -508,10 +508,9 @@ interface CharacterTemplatesProps {
   isOpen: boolean;
   onClose: () => void;
   onSelectTemplate: (template: CharacterTemplate) => void;
-  isGenerating?: boolean;
 }
 
-export function CharacterTemplates({ isOpen, onClose, onSelectTemplate, isGenerating = false }: CharacterTemplatesProps) {
+export function CharacterTemplates({ isOpen, onClose, onSelectTemplate }: CharacterTemplatesProps) {
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
   const [selectedTemplate, setSelectedTemplate] = useState<CharacterTemplate | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);

--- a/client/src/components/character/CharacterTemplates.tsx
+++ b/client/src/components/character/CharacterTemplates.tsx
@@ -9,14 +9,6 @@ import { useMutation } from '@tanstack/react-query';
 import { CharacterCreationService } from '@/lib/services/characterCreationService';
 import type { Character } from '@/lib/types';
 
-interface CharacterTemplatesProps {
-  isOpen: boolean;
-  onClose: () => void;
-  projectId: string;
-  onBack?: () => void;
-  onSelectTemplate?: (character: Character) => void;
-}
-
 interface CharacterTemplate {
   id: string;
   name: string;


### PR DESCRIPTION
Remove redundant `isGenerating` prop from `CharacterTemplates` as the state is managed internally.

---
<a href="https://cursor.com/background-agent?bcId=bc-773a5669-399d-433a-a514-109b2272929e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-773a5669-399d-433a-a514-109b2272929e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>